### PR TITLE
enlarge cache size of marketHistoryInfo

### DIFF
--- a/client/albion_state.go
+++ b/client/albion_state.go
@@ -8,7 +8,7 @@ import (
 )
 
 //CacheSize limit size of messages in cache
-const CacheSize = 256
+const CacheSize = 8192
 
 type marketHistoryInfo struct {
 	albionId  uint32


### PR DESCRIPTION
Currently marketHistoryInfo state only stores up to 256 values. As this is a global state and POW was introduced, there is a chance that index could overflow and collide, resulting in a race condition.

Even tho going from 256 to 8192 seams to be a large jump, one element is build from 1x uint32, 1x uint8 and 1x lib.Timescale. Taking a probably *way to high* estimation of 32 bytes per entry this would only result in 256 kB (8192*32) at max.

The largest index used by the game I saw was 797 before my fingers started to hurt. It might be smaller than 8192.

[90]opAuctionGetItemAverageStats - map[0:[398 549 388 458 454 531 553 484 424 291 489 430 620 644 578 499 429 522 465 351 62 419 1031 434 522] 1:[18128050000 25018070000 17745510000 20746760000 20743590000 24103760000 24934050000 21746110000 19346080000 13274150000 22118800000 19447250000 28288700000 28980260000 26379320000 22643280000 19193410000 23786730000 21320940000 15939940000 2840210000 19156420000 46959580000 19846410000 23932100000] 2:[638130636000000000 638131176000000000 638130672000000000 638130492000000000 638130852000000000 638130528000000000 638130384000000000 638131212000000000 638130564000000000 638130708000000000 638130744000000000 638130600000000000 638131068000000000 638130420000000000 638130780000000000 638131140000000000 638131248000000000 638130816000000000 638131104000000000 638130456000000000 638130888000000000 638130924000000000 638130960000000000 638130996000000000 638131032000000000] 253:90 255:797]

Many thanks to tiker from the Discord for pointing this out.