### PR TITLE
logging: add a trace facility for really verbose outputs

### DIFF
--- a/client/albion_state.go
+++ b/client/albion_state.go
@@ -53,10 +53,10 @@ func (state albionState) IsValidLocation() bool {
 func (state albionState) SetServerID() int {
 	if state.AODataServerID == 0 {
 		if strings.HasPrefix(state.GameServerIP, "5.188.125.") {
-			log.Debugf("Set Albion Data Project Server ID to 1 (src: %v)", state.GameServerIP)
+			log.Tracef("Set Albion Data Project Server ID to 1 (src: %v)", state.GameServerIP)
 			return 1
 		} else if strings.HasPrefix(state.GameServerIP, "5.45.187.") {
-			log.Debugf("Set Albion Data Project Server ID to 2 (src: %v)", state.GameServerIP)
+			log.Tracef("Set Albion Data Project Server ID to 2 (src: %v)", state.GameServerIP)
 			return 2
 		}
 	} else {

--- a/client/config.go
+++ b/client/config.go
@@ -17,6 +17,7 @@ import (
 type config struct {
 	AllowedWSHosts                 []string
 	Debug                          bool
+	Trace                          bool
 	DebugEvents                    map[int]bool
 	DebugEventsString              string
 	DebugEventsBlacklistString     string
@@ -82,6 +83,13 @@ func (config *config) setupDebugFlags() {
 		"debug",
 		false,
 		"Enable debug logging.",
+	)
+
+	flag.BoolVar(
+		&config.Trace,
+		"trace",
+		false,
+		"Enable trace logging. Even more verbose than debug.",
 	)
 
 	flag.StringVar(
@@ -189,6 +197,9 @@ func (config *config) setupCommonFlags() {
 func (config *config) setupLogs() {
 	if config.Debug {
 		config.LogLevel = "DEBUG"
+	}
+	if config.Trace {
+		config.LogLevel = "TRACE"
 	}
 
 	level, err := logrus.ParseLevel(strings.ToLower(config.LogLevel))

--- a/client/listener.go
+++ b/client/listener.go
@@ -150,11 +150,11 @@ func (l *listener) processPacket(packet gopacket.Packet) {
 	ipv4 := ipLayer.(*layers.IPv4)
 	if ipLayer != nil {
 		ipv4, _ = ipLayer.(*layers.IPv4)
-		log.Debugf("Packet came from: %s", ipv4.SrcIP)
+		log.Tracef("Packet came from: %s", ipv4.SrcIP)
 	}
 
 	if ipv4.SrcIP == nil {
-		log.Debug("No IPv4 detected")
+		log.Trace("No IPv4 detected")
 		return
 	}
 	l.router.albionstate.GameServerIP = ipv4.SrcIP.String()

--- a/log/logger.go
+++ b/log/logger.go
@@ -73,6 +73,11 @@ func Debug(args ...interface{}) {
 	logger.Debug(args...)
 }
 
+// Trace logs a message at level Trace on the standard logger.
+func Trace(args ...interface{}) {
+	logger.Trace(args...)
+}
+
 // Print logs a message at level Info on the standard logger.
 func Print(args ...interface{}) {
 	logger.Print(args...)
@@ -113,6 +118,11 @@ func Debugf(format string, args ...interface{}) {
 	logger.Debugf(format, args...)
 }
 
+// Tracef logs a message at level Trace on the standard logger.
+func Tracef(format string, args ...interface{}) {
+	logger.Tracef(format, args...)
+}
+
 // Printf logs a message at level Info on the standard logger.
 func Printf(format string, args ...interface{}) {
 	logger.Printf(format, args...)
@@ -151,6 +161,11 @@ func Fatalf(format string, args ...interface{}) {
 // Debugln logs a message at level Debug on the standard logger.
 func Debugln(args ...interface{}) {
 	logger.Debugln(args...)
+}
+
+// Traceln logs a message at level Trace on the standard logger.
+func Traceln(args ...interface{}) {
+	logger.Traceln(args...)
 }
 
 // Println logs a message at level Info on the standard logger.


### PR DESCRIPTION
* adds a `-trace` option
* adds a trace severity to the logger
* moves really frequent calls of log.Debug to log.Trace 