### PR TITLE
reintroduce a hack for 2nd Caerleon Market

### DIFF
--- a/client/operation_join.go
+++ b/client/operation_join.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/broderickhyman/albiondata-client/lib"
 	"github.com/broderickhyman/albiondata-client/log"
@@ -24,6 +25,11 @@ func (op operationJoinResponse) Process(state *albionState) {
 	// Reset the AODataServerID here. This leads to a fresh execution
 	// of SetServerID() incase the player switched servers
 	state.AODataServerID = 0
+
+	// Hack for second caerleon marketplace
+	if strings.HasSuffix(op.Location, "-Auction2") {
+		op.Location = strings.Replace(op.Location, "-Auction2", "", -1)
+	}
 
 	loc, err := strconv.Atoi(op.Location)
 	if err != nil {


### PR DESCRIPTION
There is a 2nd Caerleon Market.
The first one has ID "3005"
The second one has ID "3013-Auction2"

If we see a **location** ending with "-Auction2" we should just strip it. 
This was in the client before but it was lost during code refactoring. 

Even tho we are already altering **LocationIDs** on server side  (e.g. Portal Markets), there is an error handling in the client which prevents sending data if the **LocationID**_(string)_ cannot be converted to an integer.