### PR TITLE
Fix/linux listen devices flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ _vendor-[0-9]*
 *.gob
 scripts/albiondata-client
 albiondata-client-output.txt
+albiondata-client
 config.yaml

--- a/client/albion_watcher.go
+++ b/client/albion_watcher.go
@@ -24,11 +24,11 @@ func newAlbionProcessWatcher() *albionProcessWatcher {
 
 func (apw *albionProcessWatcher) run() error {
 	log.Print("Watching Albion")
-	physicalInterfaces, err := getAllPhysicalInterface()
-	if err != nil {
-		return err
+	if ConfigGlobal.ListenDevices != "" {
+		apw.devices = parseGivenInterfaces(ConfigGlobal.ListenDevices)
+	} else {
+		apw.devices = getAllPhysicalInterface()
 	}
-	apw.devices = physicalInterfaces
 	log.Debugf("Will listen to these devices: %v", apw.devices)
 	go apw.r.run()
 

--- a/client/net_interface_filter_nix_darw.go
+++ b/client/net_interface_filter_nix_darw.go
@@ -4,9 +4,10 @@
 package client
 
 import (
-	"log"
 	"net"
 	"strings"
+
+	"github.com/ao-data/albiondata-client/log"
 )
 
 // Check if the interface is detected
@@ -27,7 +28,15 @@ func parseGivenInterfaces(interfaces string) []string {
 	// Split the input string by comma
 	outInterfaces := strings.Split(interfaces, ",")
 	if outInterfaces == nil {
-		log.Fatal("Interfaces with name: %v not found, when parsed: %v", interfaces, outInterfaces)
+		log.Fatalf("Interfaces with name: %v not found, when parsed: %v", interfaces, outInterfaces)
+	}
+
+	for i, _interface := range outInterfaces {
+		if !isInterfacePresent(_interface) {
+			log.Debugf("Interface with name: %v not found, removing from list ...", _interface)
+			// remove the interface from the list
+			outInterfaces = append(outInterfaces[:i], outInterfaces[i+1:]...)
+		}
 	}
 
 	return outInterfaces
@@ -37,7 +46,7 @@ func parseGivenInterfaces(interfaces string) []string {
 func getAllPhysicalInterface() []string {
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		log.Fatal("Failed to get interfaces: %v", err)
+		log.Fatalf("Failed to get interfaces: %v", err)
 	}
 
 	var outInterfaces []string

--- a/client/net_interface_filter_nix_darw.go
+++ b/client/net_interface_filter_nix_darw.go
@@ -1,16 +1,43 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package client
 
 import (
+	"log"
 	"net"
+	"strings"
 )
 
-// Gets all physical interfaces based on filter results, ignoring all VM, Loopback and Tunnel interfaces.
-func getAllPhysicalInterface() ([]string, error) {
+// Check if the interface is detected
+func isInterfacePresent(_interface string) bool {
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return nil, err
+		return false
+	}
+	for _, iface := range interfaces {
+		if iface.Name == _interface {
+			return true
+		}
+	}
+	return false
+}
+
+func parseGivenInterfaces(interfaces string) []string {
+	// Split the input string by comma
+	outInterfaces := strings.Split(interfaces, ",")
+	if outInterfaces == nil {
+		log.Fatal("Interfaces with name: %v not found, when parsed: %v", interfaces, outInterfaces)
+	}
+
+	return outInterfaces
+}
+
+// Gets all physical interfaces based on filter results, ignoring all VM, Loopback and Tunnel interfaces.
+func getAllPhysicalInterface() []string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		log.Fatal("Failed to get interfaces: %v", err)
 	}
 
 	var outInterfaces []string
@@ -21,5 +48,5 @@ func getAllPhysicalInterface() ([]string, error) {
 		}
 	}
 
-	return outInterfaces, nil
+	return outInterfaces
 }


### PR DESCRIPTION
This PR add logic when passing `-l` flag with command line on linux/darwin:
`./albiondata-client -debug -l "enp6s0,notexist"`

```
❯ ./albiondata-client -debug -l "enp6s0,notexist"
INFO[2024-06-29T13:38:05+02:00] Starting Albion Data Client, version:
INFO[2024-06-29T13:38:05+02:00] This is a third-party application and is in no way affiliated with Sandbox Interactive or Albion Online.
INFO[2024-06-29T13:38:05+02:00] Additional parameters can listed by calling this file with the -h parameter.
INFO[2024-06-29T13:38:05+02:00] Watching Albion
DEBU[2024-06-29T13:38:05+02:00] Interface with name: notexist not found, removing from list ...
DEBU[2024-06-29T13:38:05+02:00] Will listen to these devices: [enp6s0]
DEBU[2024-06-29T13:38:05+02:00] Starting listener (online: enp6s0:5056)
[...]
```

Tested on `Linux 6.9.1-arch1-2`, not tested on darwin