### PR TITLE
Update operation get cluster map info response

### DIFF
--- a/client/operation_get_cluster_map_info.go
+++ b/client/operation_get_cluster_map_info.go
@@ -1,9 +1,9 @@
 package client
 
 import (
+	"github.com/ao-data/albiondata-client/lib"
 	"strconv"
 
-	"github.com/ao-data/albiondata-client/lib"
 	"github.com/ao-data/albiondata-client/log"
 	uuid "github.com/nu7hatch/gouuid"
 )
@@ -17,14 +17,16 @@ func (op operationGetClusterMapInfo) Process(state *albionState) {
 
 type operationGetClusterMapInfoResponse struct {
 	ZoneID          string   `mapstructure:"0"`
-	BuildingType    []int    `mapstructure:"5"`
-	AvailableFood   []int    `mapstructure:"10"`
-	Reward          []int    `mapstructure:"12"`
-	AvailableSilver []int    `mapstructure:"13"`
-	Owners          []string `mapstructure:"14"`
-	Buildable       []bool   `mapstructure:"19"`
-	IsForSale       []bool   `mapstructure:"27"`
-	BuyPrice        []int    `mapstructure:"28"`
+	BuildingType    []int    `mapstructure:"17"`
+	AvailableFood   []int    `mapstructure:"22"`
+	Reward          []int    `mapstructure:"23"`
+	AvailableSilver []int    `mapstructure:"24"`
+	Owners          []string `mapstructure:"25"`
+	PublicFee       []int    `mapstructure:"34"`
+	AssociateFee    []int    `mapstructure:"33"`
+	Coordinates     [][]int  `mapstructure:"18"`
+	Durability      []int    `mapstructure:"20"`
+	Permission      []int    `mapstructure:"31"`
 }
 
 func (op operationGetClusterMapInfoResponse) Process(state *albionState) {
@@ -43,9 +45,11 @@ func (op operationGetClusterMapInfoResponse) Process(state *albionState) {
 		Reward:          op.Reward,
 		AvailableSilver: op.AvailableSilver,
 		Owners:          op.Owners,
-		Buildable:       op.Buildable,
-		IsForSale:       op.IsForSale,
-		BuyPrice:        op.BuyPrice,
+		PublicFee:       op.PublicFee,
+		AssociateFee:    op.AssociateFee,
+		Coordinates:     op.Coordinates,
+		Durability:      op.Durability,
+		Permission:      op.Permission,
 	}
 
 	identifier, _ := uuid.NewV4()

--- a/lib/map.go
+++ b/lib/map.go
@@ -10,24 +10,16 @@ type MapDataUpload struct {
 	Reward          []int    `json:"Reward"`
 	AvailableSilver []int    `json:"AvailableSilver"`
 	Owners          []string `json:"Owners"`
-	Buildable       []bool   `json:"Buildable"`
-	IsForSale       []bool   `json:"IsForSale"`
-	BuyPrice        []int    `json:"BuyPrice"`
+	PublicFee       []int    `json:"PublicFee"`
+	AssociateFee    []int    `json:"AssociateFee"`
+	Coordinates     [][]int  `json:"Coordinates"`
+	Durability      []int    `json:"Durability"`
+	Permission      []int    `json:"Permission"`
 }
 
 func (m *MapDataUpload) StringArrays() [][]string {
 	result := [][]string{}
 	for i := range m.BuildingType {
-		isForSale := false
-		if len(m.IsForSale) > i {
-			isForSale = m.IsForSale[i]
-		}
-
-		buyPrice := 0
-		if len(m.BuyPrice) > i {
-			buyPrice = m.BuyPrice[i]
-		}
-
 		result = append(result, []string{
 			fmt.Sprintf("%d", m.ZoneID),
 			fmt.Sprintf("%d", m.BuildingType[i]),
@@ -35,9 +27,6 @@ func (m *MapDataUpload) StringArrays() [][]string {
 			fmt.Sprintf("%d", m.Reward[i]),
 			fmt.Sprintf("%d", m.AvailableSilver[i]),
 			m.Owners[i],
-			fmt.Sprintf("%t", m.Buildable[i]),
-			fmt.Sprintf("%t", isForSale),
-			fmt.Sprintf("%d", buyPrice),
 		})
 	}
 


### PR DESCRIPTION
I have noticed that the event for operationGetClusterMapInfo is deprecated and causes errors as the field indexes have been changed. The errors are due to incorrect casting from the original structure to the assumed structure (as the columns have been shuffled around)

### New mapping

* ZoneID: this stays the same
* BuildingType: mapped to index 17
* Available food: mapped to index 22
* Reward: mapped to index 23
* AvailableSilver: mapped to index 24
* Owners: mapped to index 25
* Buildable: REMOVED, I couldn't find the corresponding index. There are two boolean columns in the returned data for each building, but I couldn't find any correlation. It definitely didn't match what is in the current version of the code.
* IsForSale: REMOVED, same as above
* BuyPrice: REMOVED, same as above
* PublicFee: ADDED
* AssociateFee: ADDED
* Coordinates: ADDED. This is an array of four element where
  * First element denotes the axis from South West to North East 
  * Second element is the axis from South East to North West
  * Third and fourth elements are the size: 10 10 are a small building like a smelter, 20 20 are big building like sword crafting
* Durability: ADDED
* Permission: ADDED, 1: Private, 2: Public, 3: Custom

### Applications

This is an example of what can be done with this data available (assuming we will also implement this on the server side or someone adds their own public URL to the client).

I've created a small server where I receive the "map.ingest" data. We can easily get the cheapest buildings to craft items or see which ones still have  money available for food. With a bit of creativity we could use the coordinates to create a live map.

```
----- Zone: Thetford -------

Best places to craft:
Building Name             Owner                Coordinates  Info       Public Fee Food %    
--------------------------------------------------------------------------------
T8_ALCHEMIST              Aljerom              (-175,  -95) West       870        92.10%
T8_BUTCHER                Oldmen001            (-180, -120) West       375        36.11%
T8_CARPENTERSWORKSHOP     repetitor            (  35, -195) South      990        95.49%
T8_COOK                   Aljerom              (-215, -115) West       415        88.72%
T8_FORGE                  madnewmy             ( -95, -195) West       940        93.42%
T8_HUNTERSLODGE           MegaZavr             ( -75, -235) West       380        68.32%
T8_MAGICITEMS             TiborSK              ( 215,  -75) South      888        26.44%
T8_SMELTER                TiborSK              ( 120, -180) South      950        30.26%
T8_STABLE                 Xirez                ( 175,  135) East       960        74.73%
T8_TANNERY                Xirez                ( 165,  105) East       920        71.96%
T8_TOOLMAKER              Dilaudid             ( -55, -235) West       930        90.67%
T8_WEAVINGMILL            Xirez                ( 105,   65) East       980        80.75%

Places with Reward > 0 and AvailableSilver > 0:
Building Name             Owner                Coordinates  Info       Reward     Available Silver
--------------------------------------------------------------------------------
T8_ALCHEMIST              Pahqy                (  65,  175) East       400             24,594,336
T8_ALCHEMIST              Incraft              (  65, -175) South      350              3,731,800
T8_CARPENTERSWORKSHOP     repetitor            (  35, -195) South      360              6,574,002
T8_COOK                   madnewmy             (-135, -215) West       350              2,631,746
T8_COOK                   Pahqy                (  85,  155) East       400             22,573,084
T8_FORGE                  Pahqy                ( 115,  165) East       400             33,203,151
T8_HUNTERSLODGE           Pahqy                ( 105,  195) East       370              5,079,775
T8_HUNTERSLODGE           repetitor            (  35, -175) South      330             18,505,295
T8_HUNTERSLODGE           Pahqy                ( -95, -115) West       370             16,965,491
T8_MAGICITEMS             Pahqy                (  65,  205) East       390             43,117,363
T8_MAGICITEMS             repetitor            ( -45, -205) West       380              5,632,548
T8_SMELTER                Pahqy                ( -80, -120) West       375              9,618,543
T8_SMELTER                Pahqy                (  20,  170) East       400             13,736,435
T8_SMELTER                Pahqy                ( -80, -110) West       375             36,085,690
T8_SMELTER                Pahqy                (  20,  180) East       400             14,580,747
T8_STABLE                 Pahqy                (  85,  205) East       400              5,550,749
T8_TOOLMAKER              Kirahal              (  55,  -95) South      300                 25,356
```

