### PR TITLE
Fix: Use HTTPS ingest by default, respect user-defined -i URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ _vendor-[0-9]*
 scripts/albiondata-client
 albiondata-client-output.txt
 config.yaml
+albiondata-client.exe.bak
+go.mod
+rsrc_windows_386.syso
+rsrc_windows_amd64.syso

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ albiondata-client.exe.bak
 go.mod
 rsrc_windows_386.syso
 rsrc_windows_amd64.syso
+mock/*

--- a/client/config.go
+++ b/client/config.go
@@ -42,8 +42,11 @@ type config struct {
 
 // config global config data
 var ConfigGlobal = &config{
-	LogLevel: "INFO",
+	LogLevel:             "INFO",
+	PublicIngestBaseUrls: "http+pow://albion-online-data.com",
 }
+
+var PublicIngestBaseUrlsWasSet bool
 
 func (config *config) SetupFlags() {
 	config.setupWebsocketFlags()
@@ -188,12 +191,11 @@ func (config *config) setupCommonFlags() {
 		"Automatically minimize the window.",
 	)
 
-	flag.StringVar(
-		&config.PublicIngestBaseUrls,
-		"i",
-		"http+pow://albion-online-data.com",
-		"Base URL to send PUBLIC data to, can be 'nats://', 'http://' or 'noop' and can have multiple uploaders. Comma separated.",
-	)
+	flag.Func("i", "Base URL to send PUBLIC data to, can be 'nats://', 'http://' or 'noop' and can have multiple uploaders. Comma separated.", func(value string) error {
+		config.PublicIngestBaseUrls = value
+		PublicIngestBaseUrlsWasSet = true
+		return nil
+	})
 
 	flag.StringVar(
 		&config.PrivateIngestBaseUrls,

--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -38,15 +38,6 @@ func createUploaders(targets []string) []uploader {
 			continue
 		}
 
-		/**
-		* If the target starts with http://, we replace it with https://
-		* This is to ensure that we always use HTTPS for security reasons.
-		* But lets Pow targets start with http+pow://, so we don't replace those.
-		 */
-		if strings.HasPrefix(target, "http://") {
-			target = "https://" + strings.TrimPrefix(target, "http://")
-		}
-
 		if target[0:8] == "http+pow" {
 			uploaders = append(uploaders, newHTTPUploaderPow(target))
 		} else if target[0:4] == "http" {

--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -38,6 +38,15 @@ func createUploaders(targets []string) []uploader {
 			continue
 		}
 
+		/**
+		* If the target starts with http://, we replace it with https://
+		* This is to ensure that we always use HTTPS for security reasons.
+		* But lets Pow targets start with http+pow://, so we don't replace those.
+		 */
+		if strings.HasPrefix(target, "http://") {
+			target = "https://" + strings.TrimPrefix(target, "http://")
+		}
+
 		if target[0:8] == "http+pow" {
 			uploaders = append(uploaders, newHTTPUploaderPow(target))
 		} else if target[0:4] == "http" {

--- a/client/uploader_http_pow.go
+++ b/client/uploader_http_pow.go
@@ -39,8 +39,12 @@ func newHTTPUploaderPow(url string) uploader {
 		runtime.GOMAXPROCS(procs)
 	}
 
+	if !PublicIngestBaseUrlsWasSet {
+		url = strings.Replace(url, "http+pow://", "https://", 1)
+	}
+
 	return &httpUploaderPow{
-		baseURL:   strings.Replace(url, "http+pow", "https", -1),
+		baseURL:   strings.Replace(url, "http+pow", "http", 1),
 		transport: &http.Transport{},
 	}
 }

--- a/client/uploader_http_pow.go
+++ b/client/uploader_http_pow.go
@@ -40,7 +40,7 @@ func newHTTPUploaderPow(url string) uploader {
 	}
 
 	return &httpUploaderPow{
-		baseURL:   strings.Replace(url, "http+pow", "http", -1),
+		baseURL:   strings.Replace(url, "http+pow", "https", -1),
 		transport: &http.Transport{},
 	}
 }


### PR DESCRIPTION
By default, the client will use the https protocol unless a custom ingest URL is explicitly provided via the -i flag.



