### PR TITLE
Client side message deduplication

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -34,6 +34,8 @@ type config struct {
 	Offline                        bool
 	OfflinePath                    string
 	RecordPath                     string
+	Dedup                          bool
+	DedupStats                     bool
 	PrivateIngestBaseUrls          string
 	PublicIngestBaseUrls           string
 	NoCPULimit                     bool
@@ -207,6 +209,20 @@ func (config *config) setupCommonFlags() {
 		"record",
 		"",
 		"Enable recording commands to a file for debugging later.",
+	)
+
+	flag.BoolVar(
+		&config.Dedup,
+		"dedup",
+		true,
+		"Use deduplication on ingest messages to prevent upload of redundant information.",
+	)
+
+	flag.BoolVar(
+		&config.DedupStats,
+		"dedup-stats",
+		false,
+		"Print statistics on message deduplication.",
 	)
 }
 

--- a/client/ingest_msg_cache.go
+++ b/client/ingest_msg_cache.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"time"
+	"crypto/sha256"
+	"sync"
+	"github.com/ao-data/albiondata-client/log"
+)
+
+const IngestMsgCacheSize = 1024
+const IngestMsgCacheLifeTime = 600
+
+type IngestMsgCache struct{
+	entries       []IngestMsgCacheEntry
+	mutex         sync.RWMutex
+	hits          int
+	misses        int
+}
+
+type IngestMsgCacheEntry struct {
+	msghash [32]byte
+	added   time.Time
+}
+
+func (cache *IngestMsgCache) isDuplicate(msg []byte) bool {
+	if !ConfigGlobal.Dedup{
+		return false
+	}
+
+	duplicate := false
+	msghash := sha256.Sum256(msg)
+
+	cache.mutex.RLock()
+	for index, entry := range cache.entries {
+		if entry.msghash == msghash {
+			duplicate = true
+			if time.Since(entry.added).Seconds() > IngestMsgCacheLifeTime {
+				// A match has been found but it has expired
+				duplicate = false
+				cache.entries[index].msghash = [32]byte{}
+			}
+			if duplicate { break }
+		}
+	}
+	cache.mutex.RUnlock()
+
+	if !duplicate {
+		if ConfigGlobal.DedupStats{ cache.misses += 1 }
+		new_cache_entry := IngestMsgCacheEntry{
+			msghash: msghash,
+			added: time.Now(),
+		}
+		// Add the new msg that turned out to be unique to the cache
+		cache.mutex.Lock()
+		cache.entries = append(cache.entries, new_cache_entry)
+		// Chop the Cache to it's max capacity of IngestMsgCacheSize
+		// Removing the oldest entries first by removing from the front
+		if len(cache.entries) > IngestMsgCacheSize {
+			cache.entries = cache.entries[len(cache.entries)-IngestMsgCacheSize:]
+		}
+		cache.mutex.Unlock()
+	} else {
+		if ConfigGlobal.DedupStats{ cache.hits += 1 }
+	}
+	
+	return duplicate
+}
+
+func (cache *IngestMsgCache) StatsReporter() {
+	if !ConfigGlobal.Dedup {
+		// Dedup is disabled. No point in collecting stats
+		ConfigGlobal.DedupStats = false
+	} else {
+		for {
+			time.Sleep(300 * time.Second)
+			if cache.hits > 0 {
+				log.Infof("MsgCacheStatistics: %d/%d/%d%% [hits/misses/hitrate]", cache.hits, cache.misses, (cache.hits * 100) / (cache.hits + cache.misses))
+			}
+		}
+	}
+}


### PR DESCRIPTION
```
Sending 50 live market sell orders to ingest (Identifier: 48e5043b-d76b-4665-611a-cb094dd5c1d3)
Successfully sent ingest request to https://pow.europe.albion-online-data.com
Sending 50 live market sell orders to ingest (Identifier: 7e322718-f446-4207-4e38-7ec8f232188b)
CacheLookup: Message of 7e322718-f446-4207-4e38-7ec8f232188b was uploaded before. No need to upload again.
```


* Caches SHA-256 hashes of ingested messages to avoid redundant uploads.
* Checks for duplicate messages before uploading; skips upload and logs if duplicate detected.
* Keeps up to 1024 recent message hashes; old entries are expired after 600 seconds.
* Agnostic. Works on every operation (orders, gold, mapdata, ...) 
* Thread-safe with mutex locking.
* If DedupStats is enabled, logs cache hit/miss/hitrate info every 5 minutes.
* Deduplication is opt-out and statistics reporting is opt-in.
