### PR TITLE
workflow: change go-version from '1.16' to 'stable'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: stable
     - name: Build
       run: make build-linux
     - uses: shogo82148/actions-upload-release-asset@v1
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: stable
 
     - name: install nsis
       run: sudo apt-get update; sudo apt-get -y install nsis

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: stable
     - name: Build
       run: make build-linux
 
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: stable
 
     - name: install nsis
       run: sudo apt-get update; sudo apt-get -y install nsis
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: stable
 
     - name: Build
       run: go build -ldflags "-s -w -X main.version=$GITHUB_REF_NAME" albiondata-client.go


### PR DESCRIPTION
go1.16 (released 2021-02-16) is quite outdated. We should build releases with more recent version of golang but "Here be dragons" like:
* Go 1.17 requires macOS 10.13 High Sierra or later
* Go 1.18 requires Linux kernel version 2.6.32 or later.
* Go 1.20 is the last release that will run on macOS 10.13 High Sierra or 10.14 Mojave.
* Go 1.20 is the last release that will run on any release of Windows 7, 8, Server 2008 and Server 2012.