### PR TITLE
Update log message to use Infof for formatting

### DIFF
--- a/client/operation_get_cluster_map_info.go
+++ b/client/operation_get_cluster_map_info.go
@@ -53,6 +53,6 @@ func (op operationGetClusterMapInfoResponse) Process(state *albionState) {
 	}
 
 	identifier, _ := uuid.NewV4()
-	log.Info("Sending map data to ingest (Identifier: %s)", identifier)
+	log.Infof("Sending map data to ingest (Identifier: %s)", identifier)
 	sendMsgToPublicUploaders(upload, lib.NatsMapDataIngest, state, identifier.String())
 }


### PR DESCRIPTION
Made a minor improvement to the logging in the `operation_get_cluster_map_info.go` file by switching from `log.Info` to `log.Infof` to properly format the log message with the identifier.
