### PR TITLE
Add festivities event ingestion

### DIFF
--- a/client/albion_state.go
+++ b/client/albion_state.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"strings"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/ao-data/albiondata-client/lib"
@@ -20,15 +20,16 @@ type marketHistoryInfo struct {
 }
 
 type albionState struct {
-	LocationId           string
-	LocationString       string
-	CharacterId          lib.CharacterID
-	CharacterName        string
-	GameServerIP         string
-	AODataServerID       int
-	AODataIngestBaseURL  string
-	WaitingForMarketData bool
+	LocationId                   string
+	LocationString               string
+	CharacterId                  lib.CharacterID
+	CharacterName                string
+	GameServerIP                 string
+	AODataServerID               int
+	AODataIngestBaseURL          string
+	WaitingForMarketData         bool
 	BanditEventLastTimeSubmitted time.Time
+	FestivitiesLastTimeSubmitted time.Time
 
 	// A lot of information is sent out but not contained in the response when requesting marketHistory (e.g. ID)
 	// This information is stored in marketHistoryInfo

--- a/client/decode.go
+++ b/client/decode.go
@@ -141,6 +141,8 @@ func decodeEvent(params map[uint8]interface{}) (event operation, err error) {
 	//	event = &eventRedZonePlayerNotification{}
 	case evRedZoneWorldMapEvent:
 		event = &eventRedZoneWorldMapEvent{}
+	case evFestivitiesUpdate:
+		event = &eventFestivitiesUpdate{}
 	default:
 		return nil, nil
 	}

--- a/client/event_festivities_update.go
+++ b/client/event_festivities_update.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ao-data/albiondata-client/lib"
+	"github.com/ao-data/albiondata-client/log"
+	uuid "github.com/nu7hatch/gouuid"
+)
+
+const csharpTicksUnixEpoch int64 = 621355968000000000
+
+type eventFestivitiesUpdate struct {
+	Kinds       []uint8  `mapstructure:"0"`
+	Categories  []string `mapstructure:"1"`
+	UniqueNames []string `mapstructure:"2"`
+	StartTimes  []int64  `mapstructure:"3"`
+	EndTimes    []int64  `mapstructure:"4"`
+}
+
+func (event eventFestivitiesUpdate) Process(state *albionState) {
+	log.Debug("Got festivities update event...")
+
+	if !state.FestivitiesLastTimeSubmitted.IsZero() && time.Since(state.FestivitiesLastTimeSubmitted).Seconds() < 60 {
+		return
+	}
+
+	upload, err := event.upload()
+	if err != nil {
+		log.Errorf("Could not parse festivities update: %v", err)
+		return
+	}
+
+	state.FestivitiesLastTimeSubmitted = time.Now()
+
+	identifier, _ := uuid.NewV4()
+	log.Infof("Sending %d festivities to ingest (Identifier: %s)", len(upload.Events), identifier)
+	sendMsgToPublicUploaders(upload, lib.NatsFestivitiesIngest, state, identifier.String())
+}
+
+func (event eventFestivitiesUpdate) upload() (lib.FestivitiesUpload, error) {
+	count := len(event.UniqueNames)
+	if count == 0 || len(event.Kinds) != count || len(event.Categories) != count || len(event.StartTimes) != count || len(event.EndTimes) != count {
+		return lib.FestivitiesUpload{}, fmt.Errorf(
+			"inconsistent array lengths: kinds=%d categories=%d names=%d starts=%d ends=%d",
+			len(event.Kinds), len(event.Categories), count, len(event.StartTimes), len(event.EndTimes),
+		)
+	}
+
+	upload := lib.FestivitiesUpload{
+		Events: make([]*lib.Festivity, 0, count),
+	}
+
+	for i := 0; i < count; i++ {
+		uniqueName := strings.TrimSpace(event.UniqueNames[i])
+		if uniqueName == "" {
+			return lib.FestivitiesUpload{}, fmt.Errorf("empty unique name at index %d", i)
+		}
+		if event.StartTimes[i] < csharpTicksUnixEpoch || event.EndTimes[i] <= event.StartTimes[i] {
+			return lib.FestivitiesUpload{}, fmt.Errorf("invalid event interval at index %d", i)
+		}
+
+		upload.Events = append(upload.Events, &lib.Festivity{
+			Kind:       event.Kinds[i],
+			Category:   event.Categories[i],
+			UniqueName: uniqueName,
+			StartTime:  event.StartTimes[i],
+			EndTime:    event.EndTimes[i],
+		})
+	}
+
+	return upload, nil
+}

--- a/client/event_festivities_update_test.go
+++ b/client/event_festivities_update_test.go
@@ -1,0 +1,159 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ao-data/albiondata-client/lib"
+)
+
+const (
+	activitiesStartTime int64 = 639211752000000000
+	activitiesEndTime   int64 = 639212616000000000
+	gatheringEndTime    int64 = 639213480000000000
+)
+
+func testFestivitiesUpdate() eventFestivitiesUpdate {
+	return eventFestivitiesUpdate{
+		Kinds:       []uint8{2, 1},
+		Categories:  []string{"GENERAL", "GATHERING"},
+		UniqueNames: []string{"COMMON_CROSSBOW", "ORE"},
+		StartTimes:  []int64{activitiesStartTime, activitiesStartTime},
+		EndTimes:    []int64{activitiesEndTime, gatheringEndTime},
+	}
+}
+
+func TestDecodeFestivitiesUpdate(t *testing.T) {
+	operation, err := decodeEvent(map[uint8]interface{}{
+		0:   []uint8{2, 1},
+		1:   []string{"GENERAL", "GATHERING"},
+		2:   []string{"COMMON_CROSSBOW", "ORE"},
+		3:   []int64{activitiesStartTime, activitiesStartTime},
+		4:   []int64{activitiesEndTime, gatheringEndTime},
+		252: int16(evFestivitiesUpdate),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event, ok := operation.(*eventFestivitiesUpdate)
+	if !ok {
+		t.Fatalf("unexpected operation type: %T", operation)
+	}
+	if !reflect.DeepEqual(*event, testFestivitiesUpdate()) {
+		t.Fatalf("unexpected decoded event: %#v", event)
+	}
+}
+
+func TestFestivitiesUpdateUpload(t *testing.T) {
+	upload, err := testFestivitiesUpdate().upload()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := lib.FestivitiesUpload{
+		Events: []*lib.Festivity{
+			{
+				Kind:       2,
+				Category:   "GENERAL",
+				UniqueName: "COMMON_CROSSBOW",
+				StartTime:  activitiesStartTime,
+				EndTime:    activitiesEndTime,
+			},
+			{
+				Kind:       1,
+				Category:   "GATHERING",
+				UniqueName: "ORE",
+				StartTime:  activitiesStartTime,
+				EndTime:    gatheringEndTime,
+			},
+		},
+	}
+	if !reflect.DeepEqual(upload, want) {
+		t.Fatalf("unexpected upload: %#v", upload)
+	}
+}
+
+func TestFestivitiesUpdateRejectsInvalidPayload(t *testing.T) {
+	event := testFestivitiesUpdate()
+	event.EndTimes = event.EndTimes[:1]
+	if _, err := event.upload(); err == nil {
+		t.Fatal("expected inconsistent arrays to fail")
+	}
+
+	event = testFestivitiesUpdate()
+	event.EndTimes[0] = event.StartTimes[0]
+	if _, err := event.upload(); err == nil {
+		t.Fatal("expected invalid interval to fail")
+	}
+}
+
+func TestFestivitiesUpdateSendsToPublicIngest(t *testing.T) {
+	requests := make(chan lib.FestivitiesUpload, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", request.Method)
+		}
+		if request.URL.Path != "/"+lib.NatsFestivitiesIngest {
+			t.Errorf("unexpected path: %s", request.URL.Path)
+		}
+
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Error(err)
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var upload lib.FestivitiesUpload
+		if err := json.Unmarshal(body, &upload); err != nil {
+			t.Error(err)
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		requests <- upload
+		response.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldDisableUpload := ConfigGlobal.DisableUpload
+	oldPublicIngestBaseUrls := ConfigGlobal.PublicIngestBaseUrls
+	oldPrivateIngestBaseUrls := ConfigGlobal.PrivateIngestBaseUrls
+	oldEnableWebsockets := ConfigGlobal.EnableWebsockets
+	t.Cleanup(func() {
+		ConfigGlobal.DisableUpload = oldDisableUpload
+		ConfigGlobal.PublicIngestBaseUrls = oldPublicIngestBaseUrls
+		ConfigGlobal.PrivateIngestBaseUrls = oldPrivateIngestBaseUrls
+		ConfigGlobal.EnableWebsockets = oldEnableWebsockets
+	})
+
+	ConfigGlobal.DisableUpload = false
+	ConfigGlobal.PublicIngestBaseUrls = server.URL
+	ConfigGlobal.PrivateIngestBaseUrls = ""
+	ConfigGlobal.EnableWebsockets = false
+
+	state := &albionState{AODataServerID: 3}
+	event := testFestivitiesUpdate()
+	event.Process(state)
+	event.Process(state)
+
+	select {
+	case upload := <-requests:
+		if len(upload.Events) != 2 {
+			t.Fatalf("unexpected event count: %d", len(upload.Events))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for festivities upload")
+	}
+
+	select {
+	case <-requests:
+		t.Fatal("duplicate festivities upload was not throttled")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/lib/festivities.go
+++ b/lib/festivities.go
@@ -1,0 +1,15 @@
+package lib
+
+// FestivitiesUpload contains the current scheduled Albion events.
+type FestivitiesUpload struct {
+	Events []*Festivity `json:"Events"`
+}
+
+// Festivity contains one scheduled Albion event.
+type Festivity struct {
+	Kind       uint8  `json:"Kind"`
+	Category   string `json:"Category"`
+	UniqueName string `json:"UniqueName"`
+	StartTime  int64  `json:"StartTime"`
+	EndTime    int64  `json:"EndTime"`
+}

--- a/lib/nats.go
+++ b/lib/nats.go
@@ -12,6 +12,7 @@ const (
 	NatsMapDataIngest          = "mapdata.ingest"
 	NatsMapDataDeduped         = "mapdata.deduped"
 	NatsBanditEvent            = "banditevent.ingest"
+	NatsFestivitiesIngest      = "festivities.ingest"
 
 	// Private Topics
 	NatsSkillData           = "skills"


### PR DESCRIPTION
## Summary

- decode Albion's `FestivitiesUpdate` event (operation 518)
- model the decoded festivities and upload them through the existing HTTP/PoW pipeline as `festivities.ingest`
- throttle unchanged festivities uploads to one per 60 seconds
- add decoder, state, and upload tests

## Why

The game client receives the current daily and longer-running activity schedule, but it is not available from a verified public gameinfo endpoint. This extends the existing Albion Data Project packet ingestion flow so ordinary participating clients can provide that schedule.

## Server dependency

This PR depends on ao-data/albiondata-server-rails#120 and should only be released after that server change is deployed. Existing servers reject unknown ingestion topics, so releasing the client first would create failed uploads without producing usable data.

## Data and privacy

- uploads only the decoded event kind, category, unique name, start time, and end time
- does not upload raw packet captures, account identifiers, character identifiers, or position data
- uses the existing client upload and proof-of-work path

## Validation

- `go test ./...`
- `go vet ./...`
- `goimports` formatting check
- macOS arm64/amd64 and Windows amd64 builds
- local HTTP ingestion test against the companion server implementation
- live EU packet capture decoded 11 events matching the existing local snapshot collector
- `git diff --check`
