### PR TITLE
fix: stop leaking uploader connections, HTTP transports, and fragment…

### DIFF
--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
 
 	"strings"
 
@@ -16,6 +17,18 @@ type dispatcher struct{}
 var (
 	wsHub *WSHub
 	dis   *dispatcher
+
+	// uploaderCacheMu guards uploaderCache.
+	uploaderCacheMu sync.Mutex
+	// uploaderCache holds one uploader per ingest target, reused across
+	// every upload. Every market order, gold price, or mail upload calls
+	// createUploaders, and building a fresh uploader per call used to open
+	// a brand new, never-closed NATS connection (with its own internal
+	// reconnect/buffering goroutines) or a fresh http.Transport whose idle
+	// keep-alive connections were never reclaimed - both leaked memory
+	// continuously, and far more sharply during network instability, when
+	// abandoned NATS connections would sit retrying with buffered data.
+	uploaderCache = map[string]uploader{}
 )
 
 func createDispatcher() {
@@ -29,6 +42,9 @@ func createDispatcher() {
 }
 
 func createUploaders(targets []string) []uploader {
+	uploaderCacheMu.Lock()
+	defer uploaderCacheMu.Unlock()
+
 	var uploaders []uploader
 	for _, target := range targets {
 		if target == "" {
@@ -39,15 +55,25 @@ func createUploaders(targets []string) []uploader {
 			continue
 		}
 
-		if target[0:8] == "http+pow" ||  target[0:9] == "https+pow" {
-			uploaders = append(uploaders, newHTTPUploaderPow(target))
+		if cached, ok := uploaderCache[target]; ok {
+			uploaders = append(uploaders, cached)
+			continue
+		}
+
+		var u uploader
+		if target[0:8] == "http+pow" || target[0:9] == "https+pow" {
+			u = newHTTPUploaderPow(target)
 		} else if target[0:4] == "http" || target[0:5] == "https" {
-			uploaders = append(uploaders, newHTTPUploader(target))
+			u = newHTTPUploader(target)
 		} else if target[0:4] == "nats" {
-			uploaders = append(uploaders, newNATSUploader(target))
+			u = newNATSUploader(target)
 		} else {
 			log.Infof("An invalid ingest target was specified: %v", target)
+			continue
 		}
+
+		uploaderCache[target] = u
+		uploaders = append(uploaders, u)
 	}
 
 	return uploaders

--- a/client/dispatcher_test.go
+++ b/client/dispatcher_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/ao-data/albiondata-client/lib"
 )
 
+// TestCreateUploaders_ReusesUploaderForSameTarget guards against the
+// memory leak where every upload call constructed brand new uploaders
+// (a fresh NATS connection that was never closed, a fresh http.Transport
+// whose idle connections were never reclaimed) instead of reusing one
+// per ingest target.
+func TestCreateUploaders_ReusesUploaderForSameTarget(t *testing.T) {
+	target := "https://example.com/TestCreateUploaders_ReusesUploaderForSameTarget"
+
+	first := createUploaders([]string{target})
+	second := createUploaders([]string{target})
+
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("got %d and %d uploaders, want 1 and 1", len(first), len(second))
+	}
+	if first[0] != second[0] {
+		t.Fatal("createUploaders returned a different uploader instance for the same target")
+	}
+}
+
 func TestSendMsgToPublicUploaders_IncrementsCounterByRecordCount(t *testing.T) {
 	// No configured ingest targets: createUploaders returns nothing for
 	// both public and private, so this exercises the counter increment

--- a/client/photon/parser.go
+++ b/client/photon/parser.go
@@ -9,6 +9,19 @@ const (
 	photonHeaderLength   = 12
 	commandHeaderLength  = 12
 	fragmentHeaderLength = 20
+
+	// maxPendingSegments bounds how many in-progress fragment reassemblies
+	// can be tracked at once. Without this cap, a fragment lost to packet
+	// loss (e.g. during a network hiccup) leaves its entry - and the
+	// buffer it allocated - in pendingSegments forever, growing without
+	// bound as more fragmented messages arrive. When full, the oldest
+	// incomplete reassembly is evicted to make room for a new one.
+	maxPendingSegments = 64
+
+	// maxSegmentTotalLength caps the totalLength read off the wire for a
+	// fragmented message, which otherwise sizes a `make([]byte, totalLen)`
+	// allocation directly from unvalidated packet data.
+	maxSegmentTotalLength = 8 << 20 // 8 MiB
 )
 
 // Photon command type constants
@@ -54,6 +67,11 @@ type RawPacket struct {
 // https://github.com/JPCodeCraft/AlbionDataAvalonia.
 type PhotonParser struct {
 	pendingSegments map[int]*segmentedPackage
+	// segmentOrder tracks insertion order of pendingSegments keys so the
+	// oldest incomplete reassembly can be evicted once maxPendingSegments
+	// is reached. Entries for keys already removed from pendingSegments
+	// (completed or previously evicted) are skipped lazily.
+	segmentOrder []int
 
 	// OnRequest is called for every decoded OperationRequest.
 	OnRequest func(operationCode byte, params map[byte]interface{})
@@ -432,11 +450,21 @@ func (p *PhotonParser) handleSendFragment(src []byte, offset, cmdLen int) int {
 
 	seg, ok := p.pendingSegments[startSeq]
 	if !ok {
+		if totalLen <= 0 || totalLen > maxSegmentTotalLength {
+			// Corrupt or hostile totalLength - refuse to allocate for it.
+			return offset + fragLen
+		}
+
+		if len(p.pendingSegments) >= maxPendingSegments {
+			p.evictOldestSegment()
+		}
+
 		seg = &segmentedPackage{
 			totalLength: totalLen,
 			payload:     make([]byte, totalLen),
 		}
 		p.pendingSegments[startSeq] = seg
+		p.segmentOrder = append(p.segmentOrder, startSeq)
 	}
 
 	end := fragOffset + fragLen
@@ -452,6 +480,19 @@ func (p *PhotonParser) handleSendFragment(src []byte, offset, cmdLen int) int {
 	}
 
 	return offset
+}
+
+// evictOldestSegment drops the oldest incomplete fragment reassembly to
+// make room for a new one once maxPendingSegments is reached.
+func (p *PhotonParser) evictOldestSegment() {
+	for len(p.segmentOrder) > 0 {
+		oldest := p.segmentOrder[0]
+		p.segmentOrder = p.segmentOrder[1:]
+		if _, exists := p.pendingSegments[oldest]; exists {
+			delete(p.pendingSegments, oldest)
+			return
+		}
+	}
 }
 
 // available reports whether src[offset:offset+count] is in bounds.

--- a/client/photon/parser_test.go
+++ b/client/photon/parser_test.go
@@ -1,0 +1,64 @@
+package photon
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildFragmentPacket wraps a single SendFragment command into a minimal
+// valid Photon UDP packet (12-byte header + 12-byte command header +
+// 20-byte fragment header + data).
+func buildFragmentPacket(startSeq, fragCount, fragNum, totalLen, fragOffset uint32, data []byte) []byte {
+	hdr := []byte{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	fragHdr := make([]byte, fragmentHeaderLength)
+	binary.BigEndian.PutUint32(fragHdr[0:], startSeq)
+	binary.BigEndian.PutUint32(fragHdr[4:], fragCount)
+	binary.BigEndian.PutUint32(fragHdr[8:], fragNum)
+	binary.BigEndian.PutUint32(fragHdr[12:], totalLen)
+	binary.BigEndian.PutUint32(fragHdr[16:], fragOffset)
+
+	cmdData := append(fragHdr, data...)
+
+	cmdHdr := make([]byte, commandHeaderLength)
+	cmdHdr[0] = cmdSendFragment
+	binary.BigEndian.PutUint32(cmdHdr[4:], uint32(commandHeaderLength+len(cmdData)))
+
+	pkt := append(append([]byte{}, hdr...), cmdHdr...)
+	pkt = append(pkt, cmdData...)
+	return pkt
+}
+
+// TestPendingSegments_BoundedByCap verifies that incomplete fragment
+// reassembly (e.g. because a fragment was lost to packet loss during a
+// network hiccup) doesn't grow pendingSegments without bound - each
+// abandoned start-of-fragment allocates a totalLen-sized buffer that is
+// never released otherwise.
+func TestPendingSegments_BoundedByCap(t *testing.T) {
+	parser := NewPhotonParser(nil, nil, nil)
+
+	for i := 0; i < maxPendingSegments*4; i++ {
+		// Send only the first fragment of a 2-fragment message, so it never
+		// completes and stays in pendingSegments.
+		pkt := buildFragmentPacket(uint32(i), 2, 0, 20, 0, make([]byte, 10))
+		parser.ReceivePacket(pkt)
+	}
+
+	if len(parser.pendingSegments) > maxPendingSegments {
+		t.Fatalf("pendingSegments grew to %d entries, want capped at %d", len(parser.pendingSegments), maxPendingSegments)
+	}
+}
+
+// TestPendingSegments_RejectsOversizedTotalLength verifies a corrupt or
+// hostile totalLen field (read straight off the wire) can't force a huge
+// allocation.
+func TestPendingSegments_RejectsOversizedTotalLength(t *testing.T) {
+	parser := NewPhotonParser(nil, nil, nil)
+
+	pkt := buildFragmentPacket(1, 2, 0, maxSegmentTotalLength+1, 0, make([]byte, 10))
+	parser.ReceivePacket(pkt)
+
+	if len(parser.pendingSegments) != 0 {
+		t.Fatalf("pendingSegments has %d entries, want 0 for an oversized totalLen", len(parser.pendingSegments))
+	}
+}

--- a/client/uploader_http.go
+++ b/client/uploader_http.go
@@ -5,27 +5,32 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/ao-data/albiondata-client/log"
 )
 
+// httpUploadTimeout bounds every ingest HTTP request. Without it, a
+// stalled connection during a network hiccup blocks the request's
+// goroutine (one is spawned per decoded operation, see router.go)
+// forever instead of failing and letting that goroutine's memory go.
+const httpUploadTimeout = 30 * time.Second
+
 type httpUploader struct {
-	baseURL   string
-	transport *http.Transport
+	baseURL string
+	client  *http.Client
 }
 
 // newHTTPUploader creates a new HTTP uploader
 func newHTTPUploader(url string) uploader {
 	return &httpUploader{
-		baseURL:   url,
-		transport: &http.Transport{},
+		baseURL: url,
+		client:  &http.Client{Transport: &http.Transport{}, Timeout: httpUploadTimeout},
 	}
 }
 
 func (u *httpUploader) sendToIngest(body []byte, topic string, state *albionState, identifier string) {
 	// not handling sending identifier since the official usage is with http_pow
-
-	client := &http.Client{Transport: u.transport}
 
 	fullURL := u.baseURL + "/" + topic
 
@@ -37,7 +42,7 @@ func (u *httpUploader) sendToIngest(body []byte, topic string, state *albionStat
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := u.client.Do(req)
 	if err != nil {
 		log.Errorf("Error while sending ingest with data: %v", err)
 		return

--- a/client/uploader_http_pow.go
+++ b/client/uploader_http_pow.go
@@ -18,8 +18,8 @@ import (
 )
 
 type httpUploaderPow struct {
-	baseURL   string
-	transport *http.Transport
+	baseURL string
+	client  *http.Client
 }
 
 type Pow struct {
@@ -43,8 +43,8 @@ func newHTTPUploaderPow(url string) uploader {
 	url = strings.Replace(url, "http+pow", "http", -1)
 
 	return &httpUploaderPow{
-		baseURL:   url,
-		transport: &http.Transport{},
+		baseURL: url,
+		client:  &http.Client{Transport: &http.Transport{}, Timeout: httpUploadTimeout},
 	}
 }
 
@@ -52,10 +52,9 @@ func (u *httpUploaderPow) getPow(target interface{}) {
 	log.Debugf("GETTING POW")
 	fullURL := u.baseURL + "/pow"
 
-	client := &http.Client{}
 	req, _ := http.NewRequest("GET", fullURL, nil)
 	req.Header.Add("User-Agent", fmt.Sprintf("albiondata-client/%v", version))
-	resp, err := client.Do(req)
+	resp, err := u.client.Do(req)
 
 	if err != nil {
 		log.Errorf("Error in Pow Get request: %v", err)
@@ -82,7 +81,6 @@ func (u *httpUploaderPow) uploadWithPow(pow Pow, solution string, natsmsg []byte
 
 	fullURL := u.baseURL + "/pow/" + topic
 
-	client := &http.Client{}
 	data := url.Values{
 		"key":        {pow.Key},
 		"solution":   {solution},
@@ -92,7 +90,7 @@ func (u *httpUploaderPow) uploadWithPow(pow Pow, solution string, natsmsg []byte
 	}
 	req, _ := http.NewRequest("POST", fullURL, strings.NewReader(data.Encode()))
 	req.Header.Add("User-Agent", fmt.Sprintf("albiondata-client/%v", version))
-	resp, err := client.Do(req)
+	resp, err := u.client.Do(req)
 
 	if err != nil {
 		log.Errorf("Error while proving pow: %v", err)

--- a/client/uploader_http_test.go
+++ b/client/uploader_http_test.go
@@ -1,0 +1,31 @@
+package client
+
+import "testing"
+
+// TestNewHTTPUploader_SetsRequestTimeout guards against a request hanging
+// forever when the network stalls (e.g. mid connectivity issue). Combined
+// with router.go spawning one goroutine per decoded operation, a client
+// with no timeout meant a stalled upload pinned that goroutine - and
+// everything it was holding - in memory indefinitely.
+func TestNewHTTPUploader_SetsRequestTimeout(t *testing.T) {
+	u, ok := newHTTPUploader("https://example.com").(*httpUploader)
+	if !ok {
+		t.Fatalf("newHTTPUploader did not return a *httpUploader")
+	}
+	if u.client.Timeout <= 0 {
+		t.Fatalf("httpUploader.client.Timeout = %v, want a positive timeout", u.client.Timeout)
+	}
+}
+
+// TestNewHTTPUploaderPow_SetsRequestTimeout is the http+pow equivalent of
+// TestNewHTTPUploader_SetsRequestTimeout - it made two unbounded HTTP
+// calls per upload (fetch the pow challenge, then submit the solution).
+func TestNewHTTPUploaderPow_SetsRequestTimeout(t *testing.T) {
+	u, ok := newHTTPUploaderPow("https+pow://example.com").(*httpUploaderPow)
+	if !ok {
+		t.Fatalf("newHTTPUploaderPow did not return a *httpUploaderPow")
+	}
+	if u.client.Timeout <= 0 {
+		t.Fatalf("httpUploaderPow.client.Timeout = %v, want a positive timeout", u.client.Timeout)
+	}
+}


### PR DESCRIPTION
… buffers

Every market/gold/mail upload rebuilt its uploaders from scratch via createUploaders, which opened a brand new NATS connection (never closed, with its own internal reconnect/buffering goroutines) or a fresh http.Transport (idle connections never reclaimed) per call instead of reusing one per ingest target. This leaked memory continuously, and much more sharply during network instability when abandoned NATS connections sit retrying with buffered data - matching reports of memory spiking after connectivity issues. Uploaders are now cached per target.

Also added a request timeout to the HTTP/HTTP+POW uploaders (previously unbounded, and combined with router.go's one-goroutine-per-operation dispatch, a stalled connection could pin a goroutine in memory forever), and capped the Photon parser's in-progress fragment reassembly map so a fragment lost to packet loss can no longer leave a permanent, unbounded entry.